### PR TITLE
Annotate two small categories for nullability

### DIFF
--- a/RSDatabase/FMResultSet+RSExtras.h
+++ b/RSDatabase/FMResultSet+RSExtras.h
@@ -9,6 +9,8 @@
 
 #import "FMResultSet.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface FMResultSet (RSExtras)
 
 
@@ -17,3 +19,5 @@
 - (NSSet *)rs_setForSingleColumnResultSet;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/RSDatabase/NSString+RSDatabase.h
+++ b/RSDatabase/NSString+RSDatabase.h
@@ -8,6 +8,7 @@
 
 @import Foundation;
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface NSString (QSDatabase)
 
@@ -15,7 +16,7 @@
 /*Returns @"(?, ?, ?)" -- where number of ? spots is specified by numberOfValues.
  numberOfValues should be greater than 0. Triggers an NSParameterAssert if not.*/
 
-+ (NSString *)rs_SQLValueListWithPlaceholders:(NSUInteger)numberOfValues;
++ (nullable NSString *)rs_SQLValueListWithPlaceholders:(NSUInteger)numberOfValues;
 
 
 /*Returns @"(someColumn, anotherColumm, thirdColumn)" -- using passed-in keys.
@@ -31,3 +32,5 @@
 
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
These contained only helper methods which returned nonnull values, with
a single exception: `+[RSDatabase rs_SQLValueListWithPlaceholders:]`
returns nil if passed `numberOfValues == 0`. Annotate headers to match
existing behavior.